### PR TITLE
Improve `RemoveSpecialChars` function handling

### DIFF
--- a/src/services/DataHelper.js
+++ b/src/services/DataHelper.js
@@ -11,8 +11,8 @@ const IsTokenizable = (value) => value.includes("'");
 const GetList4rmString = (text) => text.split("'");
 
 const RemoveSpecialChars = (str) => {
-  const specialChars = /\r/;
-  if (specialChars.test(str)) return str.replace(/\r/, '');
+  const specialChars = /\r/g; // added 'g' flag for global replacement
+  if (specialChars.test(str)) return str.replace(specialChars, '');
   return str;
 };
 /*  Method to the ID of a stop given a stop name in a dataset which is in array format

--- a/src/services/DataHelper.test.js
+++ b/src/services/DataHelper.test.js
@@ -1,0 +1,27 @@
+import { RemoveSpecialChars } from './DataHelper';
+
+describe('RemoveSpecialChars', () => {
+  it('should remove carriage return characters from the string', () => {
+    const input = 'Hello\rWorld';
+    const expectedOutput = 'HelloWorld';
+    expect(RemoveSpecialChars(input)).toEqual(expectedOutput);
+  });
+
+  it('should remove multiple carriage return characters from the string', () => {
+    const input = 'Hello\r\rWorld';
+    const expectedOutput = 'HelloWorld';
+    expect(RemoveSpecialChars(input)).toEqual(expectedOutput);
+  });
+
+  it('should return the same string if there are no carriage return characters', () => {
+    const input = 'HelloWorld';
+    const expectedOutput = 'HelloWorld';
+    expect(RemoveSpecialChars(input)).toEqual(expectedOutput);
+  });
+
+  it('should handle empty strings', () => {
+    const input = '';
+    const expectedOutput = '';
+    expect(RemoveSpecialChars(input)).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
- Add global replacement flag to the `RemoveSpecialChars` function
- Add test file and 4 tests for `RemoveSpecialChars` function
- Fixes https://github.com/FannieMaeOpenSource/metrostop/issues/21

[src/services/DataHelper.js]
- Add 'g' flag for global replacement in the `RemoveSpecialChars` function [src/services/DataHelper.test.js]
- Add test file for `RemoveSpecialChars` function
- Add 4 tests for `RemoveSpecialChars` function