### PR TITLE
configure github action to implement CI checks on metrostop

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,3 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test


### PR DESCRIPTION
This PR will enable CI checks (build and test) on each PR that is raised against this repository to reduce the PR review and merge cycle. This will resolve #9 

https://github.com/FannieMaeOpenSource/metrostop/actions/runs/6613508703

Github Action success for node16:
<img width="1701" alt="Screenshot 2023-10-23 at 8 55 12 AM" src="https://github.com/FannieMaeOpenSource/metrostop/assets/7529330/f8ed0ab4-3c76-44c2-862b-a471f0268df3">

Github Action success for node18:
<img width="1710" alt="Screenshot 2023-10-23 at 8 55 33 AM" src="https://github.com/FannieMaeOpenSource/metrostop/assets/7529330/ac207e6b-4294-45e4-86cc-b6dfd0ca6729">
