### PR TITLE
Add SECURITY.md and vulnerability reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Issues and Bugs
+
+Please **report security issues confidentially** via GitHub [**"Report new
+vulnerability"**](https://github.com/FannieMaeOpenSource/metrostop/security/advisories/new) form.
+
+
+Please **do not use the GitHub issue tracker** to submit vulnerability reports. The issue
+tracker is intended for bug reports and to make feature requests. 


### PR DESCRIPTION
- Add a SECURITY.md file with instructions on how to report security issues confidentially
- Make clear that the GitHub issue tracker should not be used to submit vulnerability reports

[SECURITY.md]
- Add a SECURITY.md file
- Include instructions on how to confidentially report security issues via the GitHub "Report new vulnerability" form
- Make clear that the GitHub issue tracker should not be used to submit vulnerability reports


To do this, we have to enable https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability
